### PR TITLE
chore: record the the component's ref to the Labels of docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,6 +65,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME || github.actor }}
           password: ${{ secrets.DOCKERHUB_TOKEN || secrets.GHP_CRT }}
 
+      - name: Build components
+        id: build
+        run: |
+          make build-components
+          echo "record the the component's reference to the outputs of this step"
+          cat versions
+
+      - name: test
+        run: |
+          echo ref.component.Godwoken=${{ steps.build.outputs.GODWOKEN_REF }}
+          echo ref.component.Godwoken-scripts=${{ steps.build.outputs.GODWOKEN_SCRIPTS_REF }}
+          echo ref.component.Polyjuice=${{ steps.build.outputs.POLYJUICE_REF }}
+          echo ref.component.omni_lock=${{ steps.build.outputs.OMNI_LOCK_REF }}
+
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
@@ -75,9 +89,18 @@ jobs:
           # dynamically set date as a suffix
           tags: |
             type=ref,event=branch,suffix=-{{date 'YYYYMMDDHHmm'}}
-
-      - name: build
-        run: make build-components
+            type=ref,event=branch
+          labels: |
+            maintainer="Nervos Core Dev <dev@nervos.org>"
+            org.opencontainers.image.authors="Nervos Core Dev <dev@nervos.org>"
+            source.component.Godwoken="https://github.com/nervosnetwork/godwoken"
+            source.component.Godwoken-Scripts="https://github.com/nervosnetwork/godwoken-scripts"
+            source.component.Polyjuice="https://github.com/nervosnetwork/godwoken-polyjuice"
+            source.component.omni_lock="https://github.com/nervosnetwork/ckb-production-scripts"
+            ref.component.Godwoken=${{ steps.build.outputs.GODWOKEN_REF }}
+            ref.component.Godwoken-scripts=${{ steps.build.outputs.GODWOKEN_SCRIPTS_REF }}
+            ref.component.Polyjuice=${{ steps.build.outputs.POLYJUICE_REF }}
+            ref.component.omni_lock=${{ steps.build.outputs.OMNI_LOCK_REF }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -101,13 +124,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      # - name: Check versions of the binaries used by Godwoken
-      #   run: |
-      # FIXME: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by godwoken)
-      #     docker run --rm godwoken-prebuilds godwoken --version
-      #     docker run --rm godwoken-prebuilds gw-tools --version
-      ###
-      #     docker run --rm godwoken-prebuilds ckb --version
-      #     docker run --rm godwoken-prebuilds ckb-cli --version
-      #     docker run --rm godwoken-prebuilds ckb-indexer --version
-      #     docker run --rm godwoken-prebuilds find /scripts
+      - name: Check versions of the binaries in ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        env:
+          IMAGE: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        run: |
+          docker run --rm ${{ env.IMAGE }} godwoken --version
+          docker run --rm ${{ env.IMAGE }} gw-tools --version
+          docker run --rm ${{ env.IMAGE }} ckb --version
+          docker run --rm ${{ env.IMAGE }} ckb-cli --version
+          docker run --rm ${{ env.IMAGE }} ckb-indexer --version
+          docker run --rm ${{ env.IMAGE }} find /scripts

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -93,14 +93,14 @@ jobs:
           labels: |
             maintainer="Nervos Core Dev <dev@nervos.org>"
             org.opencontainers.image.authors="Nervos Core Dev <dev@nervos.org>"
-            source.component.Godwoken="https://github.com/nervosnetwork/godwoken"
-            source.component.Godwoken-Scripts="https://github.com/nervosnetwork/godwoken-scripts"
-            source.component.Polyjuice="https://github.com/nervosnetwork/godwoken-polyjuice"
-            source.component.omni_lock="https://github.com/nervosnetwork/ckb-production-scripts"
-            ref.component.Godwoken=${{ steps.build.outputs.GODWOKEN_REF }}
-            ref.component.Godwoken-scripts=${{ steps.build.outputs.GODWOKEN_SCRIPTS_REF }}
-            ref.component.Polyjuice=${{ steps.build.outputs.POLYJUICE_REF }}
-            ref.component.omni_lock=${{ steps.build.outputs.OMNI_LOCK_REF }}
+            source.component.godwoken=https://github.com/nervosnetwork/godwoken
+            source.component.godwoken-scripts-Scripts=https://github.com/nervosnetwork/godwoken-scripts
+            source.component.godwoken-polyjuice=https://github.com/nervosnetwork/godwoken-polyjuice
+            source.component.ckb-production-scripts=https://github.com/nervosnetwork/ckb-production-scripts
+            ref.component.godwoken=${{ steps.build.outputs.GODWOKEN_REF }}
+            ref.component.godwoken-scripts=${{ steps.build.outputs.GODWOKEN_SCRIPTS_REF }}
+            ref.component.godwoken-polyjuice=${{ steps.build.outputs.POLYJUICE_REF }}
+            ref.component.ckb-production-scripts=${{ steps.build.outputs.OMNI_LOCK_REF }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -133,4 +133,4 @@ jobs:
           docker run --rm ${{ env.IMAGE }} ckb --version
           docker run --rm ${{ env.IMAGE }} ckb-cli --version
           docker run --rm ${{ env.IMAGE }} ckb-indexer --version
-          docker run --rm ${{ env.IMAGE }} find /scripts
+          docker run --rm ${{ env.IMAGE }} find /scripts -type f -exec sha1sum {} \;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM rust:1 as builder
-MAINTAINER Xuejie Xiao <x@nervos.org>
 
 RUN apt-get update
 RUN apt-get -y install --no-install-recommends llvm-dev clang libclang-dev libssl-dev
@@ -18,7 +17,6 @@ RUN cd /ckb-indexer && curl -LO https://github.com/nervosnetwork/ckb-indexer/rel
 RUN cd /ckb-indexer && unzip ckb-indexer-0.3.2-linux.zip && tar xzf ckb-indexer-linux-x86_64.tar.gz
 
 FROM ubuntu:21.04
-MAINTAINER Xuejie Xiao <x@nervos.org>
 
 RUN mkdir -p /scripts/godwoken-scripts \
  && mkdir -p /scripts/godwoken-polyjuice

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,13 @@ endef
 prepare-repos:
 	mkdir -p build
 	$(call prepare_repo,$(GODWOKEN_REPO),$(GODWOKEN_REF),godwoken)
-	echo "::set-output name=GODWOKEN_REF::$(GODWOKEN_REF)-$$(cd build/godwoken && git rev-parse HEAD)" >> versions
+	echo "::set-output name=GODWOKEN_REF::$(GODWOKEN_REF)\ $$(cd build/godwoken && git rev-parse --short HEAD)" >> versions
 	$(call prepare_repo,$(GODWOKEN_SCRIPTS_REPO),$(GODWOKEN_SCRIPTS_REF),godwoken-scripts)
-	echo "::set-output name=GODWOKEN_SCRIPTS_REF::$(GODWOKEN_SCRIPTS_REF)-$$(cd build/godwoken-scripts && git rev-parse HEAD)" >> versions
+	echo "::set-output name=GODWOKEN_SCRIPTS_REF::$(GODWOKEN_SCRIPTS_REF)\ $$(cd build/godwoken-scripts && git rev-parse --short HEAD)" >> versions
 	$(call prepare_repo,$(POLYJUICE_REPO),$(POLYJUICE_REF),godwoken-polyjuice)
-	echo "::set-output name=POLYJUICE_REF::$(POLYJUICE_REF)-$$(cd build/godwoken-polyjuice && git rev-parse HEAD)" >> versions
+	echo "::set-output name=POLYJUICE_REF::$(POLYJUICE_REF)\ $$(cd build/godwoken-polyjuice && git rev-parse --short HEAD)" >> versions
 	$(call prepare_repo,$(OMNI_LOCK_REPO),$(OMNI_LOCK_REF),ckb-production-scripts)
-	echo "::set-output name=OMNI_LOCK_REF::$(OMNI_LOCK_REF)-$$(cd build/ckb-production-scripts && git rev-parse HEAD)" >> versions
+	echo "::set-output name=OMNI_LOCK_REF::$(OMNI_LOCK_REF)\ $$(cd build/ckb-production-scripts && git rev-parse --short HEAD)" >> versions
 
 build-components: prepare-repos
 	cd build/godwoken-polyjuice && make dist && cd -

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 GODWOKEN_REPO := https://github.com/nervosnetwork/godwoken.git
 GODWOKEN_SCRIPTS_REPO := https://github.com/nervosnetwork/godwoken-scripts.git
 POLYJUICE_REPO := https://github.com/nervosnetwork/godwoken-polyjuice.git
-OMNI_LOCK_REPO := https://github.com/nervosnetwork/ckb-production-scripts
+OMNI_LOCK_REPO := https://github.com/nervosnetwork/ckb-production-scripts.git
 
 # components tags
 GODWOKEN_REF := compatibility-breaking-changes
@@ -15,9 +15,8 @@ OMNI_LOCK_REF := rc_lock
 define prepare_repo
 	if [ -d "build/$(3)" ]; then\
 		cd build/$(3);\
-		git reset --hard;\
-		git fetch --all;\
-		git checkout $(2);\
+		git fetch origin $(2);\
+		git checkout FETCH_HEAD;\
 		git submodule update --init --recursive --depth=1;\
 	else\
 		git clone --depth=1 --recursive $(1) -b $(2) build/$(3);\
@@ -27,9 +26,13 @@ endef
 prepare-repos:
 	mkdir -p build
 	$(call prepare_repo,$(GODWOKEN_REPO),$(GODWOKEN_REF),godwoken)
+	echo "::set-output name=GODWOKEN_REF::$(GODWOKEN_REF)-$$(cd build/godwoken && git rev-parse HEAD)" >> versions
 	$(call prepare_repo,$(GODWOKEN_SCRIPTS_REPO),$(GODWOKEN_SCRIPTS_REF),godwoken-scripts)
+	echo "::set-output name=GODWOKEN_SCRIPTS_REF::$(GODWOKEN_SCRIPTS_REF)-$$(cd build/godwoken-scripts && git rev-parse HEAD)" >> versions
 	$(call prepare_repo,$(POLYJUICE_REPO),$(POLYJUICE_REF),godwoken-polyjuice)
+	echo "::set-output name=POLYJUICE_REF::$(POLYJUICE_REF)-$$(cd build/godwoken-polyjuice && git rev-parse HEAD)" >> versions
 	$(call prepare_repo,$(OMNI_LOCK_REPO),$(OMNI_LOCK_REF),ckb-production-scripts)
+	echo "::set-output name=OMNI_LOCK_REF::$(OMNI_LOCK_REF)-$$(cd build/ckb-production-scripts && git rev-parse HEAD)" >> versions
 
 build-components: prepare-repos
 	cd build/godwoken-polyjuice && make dist && cd -


### PR DESCRIPTION
This PR adds the component's ref to the Labels of docker image, including:
```
# components tags
GODWOKEN_REF
GODWOKEN_SCRIPTS_REF
POLYJUICE_REF
OMNI_LOCK_REF
```

You can use `docker inspect <image_name:tag>` to check the labels info.